### PR TITLE
Make End Enderman have teleport cooldowns via configuration

### DIFF
--- a/common/src/main/generated/resources/assets/endermanoverhaul/lang/en_us.json
+++ b/common/src/main/generated/resources/assets/endermanoverhaul/lang/en_us.json
@@ -3,6 +3,7 @@
   "config.endermanoverhaul.allowPickingUpBlocks": "Allow Picking Up Blocks",
   "config.endermanoverhaul.allowSpawning": "Allow Spawning",
   "config.endermanoverhaul.endEndermanTeleportChance": "End Enderman Teleport Chance",
+  "config.endermanoverhaul.endEndermanTeleportCooldown": "End Enderman Teleport Cooldown",
   "config.endermanoverhaul.friendlyEndermanDespawn": "Friendly Enderman Despawn",
   "config.endermanoverhaul.friendlyEndermanTeleport": "Friendly Enderman Teleport",
   "config.endermanoverhaul.replaceDefaultEnderman": "Replace Default Enderman",

--- a/common/src/main/java/tech/alexnijjar/endermanoverhaul/common/config/EndermanOverhaulConfig.java
+++ b/common/src/main/java/tech/alexnijjar/endermanoverhaul/common/config/EndermanOverhaulConfig.java
@@ -187,4 +187,12 @@ public final class EndermanOverhaulConfig {
     )
     @Comment("The chance that an End Enderman will teleport you when it hits you")
     public static float endEndermanTeleportChance = 0.5f;
+
+    @ConfigEntry(
+        id = "endEndermanTeleportCooldown",
+        type = EntryType.INTEGER,
+        translation = "config.endermanoverhaul.endEndermanTeleportCooldown"
+    )
+    @Comment("The cooldown time in seconds that enderman have before they can teleport you again")
+    public static int endEndermanTeleportCooldown = 0;
 }

--- a/common/src/main/java/tech/alexnijjar/endermanoverhaul/common/entities/EndEnderman.java
+++ b/common/src/main/java/tech/alexnijjar/endermanoverhaul/common/entities/EndEnderman.java
@@ -28,9 +28,12 @@ import tech.alexnijjar.endermanoverhaul.common.constants.ConstantAnimations;
 import tech.alexnijjar.endermanoverhaul.common.entities.base.BaseEnderman;
 import tech.alexnijjar.endermanoverhaul.common.registry.ModSoundEvents;
 
+import java.util.Date;
+
 public class EndEnderman extends BaseEnderman {
     private static final EntityDataAccessor<Integer> DATA_BITING_TICKS = SynchedEntityData.defineId(EndEnderman.class, EntityDataSerializers.INT);
 
+    private long lastTeleportTime = 0L;
     public EndEnderman(EntityType<? extends EnderMan> entityType, Level level) {
         super(entityType, level);
         xpReward = 8;
@@ -128,8 +131,11 @@ public class EndEnderman extends BaseEnderman {
         if (super.doHurtTarget(target)) {
             this.playSound(SoundEvents.PHANTOM_BITE, 10.0f, 0.95f + this.random.nextFloat() * 0.1f);
             entityData.set(DATA_BITING_TICKS, 7);
-            if (target instanceof LivingEntity entity && random.nextFloat() < EndermanOverhaulConfig.endEndermanTeleportChance) {
+            final long currentTime = new Date().getTime();
+            final long differenceSeconds = (currentTime - this.lastTeleportTime) / 1000;
+            if (target instanceof LivingEntity entity && random.nextFloat() < EndermanOverhaulConfig.endEndermanTeleportChance && differenceSeconds > EndermanOverhaulConfig.endEndermanTeleportCooldown) {
                 ModUtils.teleportTarget(level(), entity, 24);
+                this.lastTeleportTime = currentTime;
             }
             return true;
         } else {


### PR DESCRIPTION
Love this mod, but kinda got a little angry with these end enderman in ATM9 so I rage-added in cooldowns for End Enderman teleports, was going to just make this a suggestion buts its relatively simple so thought ide just make the PR my suggestions

Dunno much about how architectury works so I'm sure I might of not done something correctly for the `/generated` directory (I just manually added in my config-en_us line) 