### PR TITLE
(Issue #86) Add new spawn tag for mushroom fields biome

### DIFF
--- a/src/main/resources/data/endermanoverhaul/tags/worldgen/biome/mushroom_fields_spawns.json
+++ b/src/main/resources/data/endermanoverhaul/tags/worldgen/biome/mushroom_fields_spawns.json
@@ -1,6 +1,10 @@
 {
   "values": [
     {
+      "id": "#c:is_mushroom",
+      "required": false
+    },
+    {
       "id": "#c:mushroom",
       "required": false
     },


### PR DESCRIPTION
Mushroom Fields Endermen would not spawn in mushroom biomes (Issue #86 ). Added tag #c:is_mushroom to the spawns, which includes biomes like vanilla Mushroom Fields. Tested with Delightful Dirt from Mob Grinding Utils to speed up spawn rates, and they started spawning with this patch. The new tag is the only change.